### PR TITLE
Admin authorization refactor

### DIFF
--- a/app/controllers/admin/api/v1/base_controller.rb
+++ b/app/controllers/admin/api/v1/base_controller.rb
@@ -2,18 +2,14 @@ class Admin::Api::V1::BaseController < ActionController::API
   before_action :require_admin!
 
   def require_admin!
-    four_oh_four unless current_user.admin?
+    four_oh_four unless current_user&.admin?
   end
 
   def current_user
-    @current_user ||= if session[:user_id]
-                        User.find(session[:user_id])
-                      else
-                        User.new
-                      end
+    @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
 
   def four_oh_four
-    raise ActionController::RoutingError, 'Not Found'
+    render status: 404, file: "#{Rails.root}/public/404.html"
   end
 end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -2,6 +2,6 @@ class Admin::BaseController < ApplicationController
   before_action :require_admin!
 
   def require_admin!
-    four_oh_four unless current_user.admin?
+    four_oh_four unless current_user&.admin?
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,6 @@ class ApplicationController < ActionController::Base
   end
 
   def four_oh_four
-    raise ActionController::RoutingError, 'Not Found'
+    render status: 404, file: "#{Rails.root}/public/404.html"
   end
 end

--- a/spec/features/admin/authorization_spec.rb
+++ b/spec/features/admin/authorization_spec.rb
@@ -15,5 +15,5 @@ describe 'Admin authorization' do
     visit admin_dashboard_path
 
     expect(page.status_code).to eq(404)
-  end  
+  end
 end

--- a/spec/features/admin/authorization_spec.rb
+++ b/spec/features/admin/authorization_spec.rb
@@ -1,12 +1,19 @@
 require 'rails_helper'
 
 describe 'Admin authorization' do
-  scenario 'Non admin users cannot access Admin paths' do
+  scenario 'Unregistered users cannot access Admin paths' do
+    visit admin_dashboard_path
+
+    expect(page.status_code).to eq(404)
+  end
+
+  scenario 'Registered users cannot access Admin paths' do
     user = create(:user)
     allow_any_instance_of(ApplicationController)
       .to receive(:current_user).and_return(user)
 
-    expect { visit admin_dashboard_path }
-      .to raise_error(ActionController::RoutingError)
-  end
+    visit admin_dashboard_path
+
+    expect(page.status_code).to eq(404)
+  end  
 end


### PR DESCRIPTION
Refactored the admin authorization to render 404 instead of exposing the routes.

Also added a test for unregistered users to also see the 404 page when attempting to access admin only routes.

closes #32 