### PR TITLE
Refactored bookmarked_videos to load videos to correct n+1 query

### DIFF
--- a/app/facades/user_information_facade.rb
+++ b/app/facades/user_information_facade.rb
@@ -6,8 +6,8 @@ class UserInformationFacade
 
   def bookmarked_videos
     Video.joins(:user_videos)
-    .where('user_videos.user_id': @current_user.id)
-    .order(:tutorial_id, :position)
+         .where('user_videos.user_id': @current_user.id)
+         .order(:tutorial_id, :position)
   end
 
   def top_repos

--- a/app/facades/user_information_facade.rb
+++ b/app/facades/user_information_facade.rb
@@ -5,7 +5,9 @@ class UserInformationFacade
   end
 
   def bookmarked_videos
-    @current_user.videos.order(:tutorial_id, :position)
+    Video.joins(:user_videos)
+    .where('user_videos.user_id': @current_user.id)
+    .order(:tutorial_id, :position)
   end
 
   def top_repos


### PR DESCRIPTION
Relevent cards: #11 & #38 

#11 requests:
- Only makes one query to the database (no n+1 queries)
- Avoids loading all videos into memory

I believe this refactor addresses the n+1 query.  However, I am unclear on how to build this feature without loading all videos into memory.  Any suggestions?