### PR TITLE
Switched to buttons for adding friends for Heroku

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -56,7 +56,7 @@
           <%= link_to follower.name, follower.link%>
           <% if follower.user_id%>
             <% if current_user.not_friends_with(follower.github_uid) %>
-              <%= link_to "Add as Friend", friendships_path(params:{github_uid: follower.github_uid}), method: :post %>
+              <%= button_to "Add as Friend", friendships_path(params:{github_uid: follower.github_uid}) %>
             <% else %>
               is a Friend
             <%end%>
@@ -71,7 +71,7 @@
           <%= link_to following.name, following.link%>
           <% if following.user_id%>
             <% if current_user.not_friends_with(following.github_uid) %>
-              <%= link_to "Add as Friend", friendships_path(params:{github_uid: following.github_uid}), method: :post %>
+              <%= button_to "Add as Friend", friendships_path(params:{github_uid: following.github_uid}) %>
             <% else %>
               is a Friend
             <%end%>

--- a/spec/features/user/user_can_add_friends_spec.rb
+++ b/spec/features/user/user_can_add_friends_spec.rb
@@ -74,9 +74,9 @@ describe 'A registered user', :vcr do
       followers = all('.follower-link')
       followers.each do |f|
         if f.text.include?('NoAccount')
-          expect(f).not_to have_link('Add as Friend')
+          expect(f).not_to have_button('Add as Friend')
         else
-          expect(f).to have_link('Add as Friend')
+          expect(f).to have_button('Add as Friend')
         end
       end
     end
@@ -87,9 +87,9 @@ describe 'A registered user', :vcr do
       followers = all('.follower-link')
       followers.each do |f|
         if f.text.include?('NoAccount')
-          expect(f).not_to have_link('Add as Friend')
+          expect(f).not_to have_button('Add as Friend')
         else
-          expect(f).to have_link('Add as Friend')
+          expect(f).to have_button('Add as Friend')
         end
       end
     end


### PR DESCRIPTION
Co-authored-by: William Peterson <29714514+wipegup@users.noreply.github.com>

Changes add friends from links to buttons. Heroku was defaulting them to a get request instead of a post.